### PR TITLE
Added support for Eddystone-UID

### DIFF
--- a/PyBeacon/PyBeacon.py
+++ b/PyBeacon/PyBeacon.py
@@ -38,6 +38,9 @@ else:
 # The default url
 default_url = "https://goo.gl/SkcDTN"
 
+# The default uid
+default_uid = "01234567890123456789012345678901"
+
 schemes = [
         "http://www.",
         "https://www.",
@@ -61,8 +64,8 @@ parser = argparse.ArgumentParser(prog=application_name, description= __doc__)
 
 parser.add_argument("-u", "--url", nargs='?', const=default_url, type=str,
     default=default_url, help='URL to advertise.')
-parser.add_argument("-i", "--uid", nargs='+', type=str,
-    help='UID to advertise.')
+parser.add_argument("-i", "--uid", nargs='?', const=default_uid, type=str,
+    default=default_uid, help='UID to advertise.')
 parser.add_argument('-s','--scan', action='store_true',
                     help='Scan for URLs.')
 parser.add_argument('-t','--terminate', action='store_true',

--- a/PyBeacon/PyBeacon.py
+++ b/PyBeacon/PyBeacon.py
@@ -118,6 +118,8 @@ def encode_uid(uid):
     ret = []
     for i in range(0, len(uid), 2):
         ret.append(int(uid[i:i+2], 16))
+    ret.append(0x00)
+    ret.append(0x00)
     return ret
 
 
@@ -230,12 +232,21 @@ def onUrlFound(url):
     """
 
     url = resolveUrl(url)
+    sys.stdout.write("\n/*          Eddystone-URL         */\n")
     sys.stdout.write(url)
     sys.stdout.write("\n")
     sys.stdout.flush()
 
 
 foundPackets = set()
+
+
+def on_uid_found(bytearray):
+    print("\n/*       Eddystone-UID      */")
+    namespace = ("".join(format(x, '02x') for x in bytearray[0:10]))
+    instance = ("".join(format(x, '02x') for x in bytearray[10:16]))
+    print("Namspace: {}\nInstance: {}\n".format(namespace, instance))
+
 
 def onPacketFound(packet):
     """
@@ -256,11 +267,11 @@ def onPacketFound(packet):
         frameType = data[25]
 
         # Eddystone-URL
-        if frameType == Eddystone.url:
-            verboseOutput("Eddystone-URL")
+        if frameType == Eddystone.url.value:
             onUrlFound(decodeUrl(data[27:22 + serviceDataLength]))
-        elif frameType == Eddystone.uid:
-            verboseOutput("Eddystone-UID")
+        elif frameType == Eddystone.uid.value:
+            on_uid_found(data[27:22 + serviceDataLength])
+
         elif frameType == Eddystone.tlm:
             verboseOutput("Eddystone-TLM")
         else:

--- a/PyBeacon/PyBeacon.py
+++ b/PyBeacon/PyBeacon.py
@@ -37,10 +37,10 @@ else:
     DEVNULL = open(os.devnull, 'wb')
 
 # The default url
-default_url = "https://goo.gl/SkcDTN"
+defaultUrl = "https://goo.gl/SkcDTN"
 
 # The default uid
-default_uid = "01234567890123456789012345678901"
+defaultUid = "01234567890123456789012345678901"
 
 schemes = [
         "http://www.",
@@ -63,10 +63,10 @@ extensions = [
 
 parser = argparse.ArgumentParser(prog=application_name, description= __doc__)
 
-parser.add_argument("-u", "--url", nargs='?', const=default_url, type=str,
-    default=default_url, help='URL to advertise.')
-parser.add_argument("-i", "--uid", nargs='?', const=default_uid, type=str,
-    default=default_uid, help='UID to advertise.')
+parser.add_argument("-u", "--url", nargs='?', const=defaultUrl, type=str,
+                    default=defaultUrl, help='URL to advertise.')
+parser.add_argument("-i", "--uid", nargs='?', const=defaultUid, type=str,
+                    default=defaultUid, help='UID to advertise.')
 parser.add_argument('-s','--scan', action='store_true',
                     help='Scan for URLs.')
 parser.add_argument('-t','--terminate', action='store_true',
@@ -116,8 +116,8 @@ def encodeurl(url):
     return data
 
 
-def encode_uid(uid):
-    if not uid_is_valid(uid):
+def encodeUid(uid):
+    if not uidIsValid(uid):
         raise ValueError("Invalid uid. Please specify a valid 16-byte (e.g 32 hex digits) hex string")
     ret = []
     for i in range(0, len(uid), 2):
@@ -127,7 +127,7 @@ def encode_uid(uid):
     return ret
 
 
-def uid_is_valid(uid):
+def uidIsValid(uid):
     if len(uid) == 32:
         try:
             int(uid, 16)
@@ -142,7 +142,7 @@ def encodeMessage(data, beacon_type=Eddystone.url):
     if beacon_type == Eddystone.url:
         payload = encodeurl(data)
     elif beacon_type == Eddystone.uid:
-        payload = encode_uid(data)
+        payload = encodeUid(data)
     encodedmessageLength = len(payload)
 
     verboseOutput("Encoded message length: " + str(encodedmessageLength))
@@ -245,7 +245,7 @@ def onUrlFound(url):
 foundPackets = set()
 
 
-def on_uid_found(bytearray):
+def onUidFound(bytearray):
     print("\n/*       Eddystone-UID      */")
     namespace = ("".join(format(x, '02x') for x in bytearray[0:10]))
     instance = ("".join(format(x, '02x') for x in bytearray[10:16]))
@@ -274,7 +274,7 @@ def onPacketFound(packet):
         if frameType == Eddystone.url.value:
             onUrlFound(decodeUrl(data[27:22 + serviceDataLength]))
         elif frameType == Eddystone.uid.value:
-            on_uid_found(data[27:22 + serviceDataLength])
+            onUidFound(data[27:22 + serviceDataLength])
         elif frameType == Eddystone.tlm.value:
             verboseOutput("Eddystone-TLM")
         else:

--- a/PyBeacon/PyBeacon.py
+++ b/PyBeacon/PyBeacon.py
@@ -23,11 +23,12 @@ import subprocess
 import sys
 import time
 import argparse
+from . import __version__
 from pprint import pprint
 from enum import Enum
 
 application_name = 'PyBeacon'
-version = '0.2.5' + 'beta'
+version = __version__ + 'beta'
 
 
 if (sys.version_info > (3, 0)):
@@ -274,8 +275,7 @@ def onPacketFound(packet):
             onUrlFound(decodeUrl(data[27:22 + serviceDataLength]))
         elif frameType == Eddystone.uid.value:
             on_uid_found(data[27:22 + serviceDataLength])
-
-        elif frameType == Eddystone.tlm:
+        elif frameType == Eddystone.tlm.value:
             verboseOutput("Eddystone-TLM")
         else:
             verboseOutput("Unknown Eddystone frame type: {}".format(frameType))

--- a/PyBeacon/PyBeacon.py
+++ b/PyBeacon/PyBeacon.py
@@ -61,7 +61,7 @@ parser = argparse.ArgumentParser(prog=application_name, description= __doc__)
 
 parser.add_argument("-u", "--url", nargs='?', const=default_url, type=str,
     default=default_url, help='URL to advertise.')
-parser.add_argument("-i", "--uid", nargs='?', type=str,
+parser.add_argument("-i", "--uid", nargs='+', type=str,
     help='UID to advertise.')
 parser.add_argument('-s','--scan', action='store_true',
                     help='Scan for URLs.')

--- a/PyBeacon/PyBeacon.py
+++ b/PyBeacon/PyBeacon.py
@@ -62,11 +62,12 @@ extensions = [
         ]
 
 parser = argparse.ArgumentParser(prog=application_name, description= __doc__)
+group = parser.add_mutually_exclusive_group()
 
-parser.add_argument("-u", "--url", nargs='?', const=defaultUrl, type=str,
+group.add_argument("-u", "--url", nargs='?', const=defaultUrl, type=str,
                     default=defaultUrl, help='URL to advertise.')
-parser.add_argument("-i", "--uid", nargs='?', const=defaultUid, type=str,
-                    default=defaultUid, help='UID to advertise.')
+group.add_argument("-i", "--uid", nargs='?',  type=str,
+                    const=defaultUid, help='UID to advertise.')
 parser.add_argument('-s','--scan', action='store_true',
                     help='Scan for URLs.')
 parser.add_argument('-t','--terminate', action='store_true',

--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ Python script for scanning and advertising urls over [Eddystone-URL](https://git
 	optional arguments:
 		-h, --help            show this help message and exit
 		-u [URL], --url [URL] URL to advertise.
+		-i [UID], --uid [UID] UID to advertise.
 		-s, --scan            Scan for URLs.
 		-t, --terminate       Stop advertising URL.
 		-o, --one             Scan one URL only.


### PR DESCRIPTION
This pull request adds support for Eddystone-UID to PyBeacon, in terms of both advertising and scanning uid beacons.

Some notes:

- I 've changed the printed message on scanning to include the beacon type (that was only printed when verbose was provided).
- I 've kept as default behavior (e.g when no arguments provided), the advertisement of the example url.
- I would propose some refactoring on PyBeacon.py, so as to adhere to the [PEP 8 style guidelines](https://www.python.org/dev/peps/pep-0008/). I didn't want to make such changes in the context of this pull request - we could open a new Issue/pull request for this if you agree...

Please review / test my PR, and if you have any concerns or spot any issues please let me know so that I can fix them!

Thx!